### PR TITLE
Fix off-by-one error in Windows screen calculation

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -41,8 +41,8 @@ pub fn dimensions() -> Option<(usize, usize)> {
     };
 
     if unsafe { GetConsoleScreenBufferInfo(stdout_h, &mut console_data) } != 0 {
-        Some(((console_data.srWindow.Right - console_data.srWindow.Left) as usize,
-                (console_data.srWindow.Bottom - console_data.srWindow.Top) as usize))
+        Some(((console_data.srWindow.Right - console_data.srWindow.Left + 1) as usize,
+                (console_data.srWindow.Bottom - console_data.srWindow.Top + 1) as usize))
     } else {
         None
     }


### PR DESCRIPTION
Prior art:
- https://github.com/softprops/termsize/blob/10ea56487415e14190ff623895d58e7e9a809bbe/src/win.rs#L35-L36
- https://github.com/eminence/terminal-size/blob/10222f9aeca3c5a1d097df23ee77db0ae8f2a208/src/windows.rs#L34-L35

Also tested using `cmd.exe`/`powershell.exe` and the new values match Layout > Window Size dimensions as expected